### PR TITLE
Switch to refresh_token grant for Stitch OAuth compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+  * Switch authentication from `client_credentials` to `refresh_token` grant to support Stitch platform OAuth flow. [#13](https://github.com/singer-io/tap-ms-teams/pull/13)
+  * Write rotated `refresh_token` back to config file when Microsoft issues a new one.
+  * Add `refresh_token` to required config keys.
+
 ## 1.0.0
   * Bump versions singer-python and requests modules. [#11](https://github.com/singer-io/tap-ms-teams/pull/11)
   * Updated schema files, update composite primary key for groups child streams.[#7](https://github.com/singer-io/tap-ms-teams/pull/7)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ms-teams',
-      version='1.0.0',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Microsofts Teams Graph API',
       author='scott.coleman@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_ms_teams/__init__.py
+++ b/tap_ms_teams/__init__.py
@@ -102,12 +102,12 @@ def sync(client, config, catalog, state):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(required_config_keys=[
-        'client_id', 'client_secret', 'tenant_id', 'start_date', 'user_agent'
+        'client_id', 'client_secret', 'tenant_id', 'refresh_token', 'start_date', 'user_agent'
     ])
     config = parsed_args.config
 
     try:
-        client = MicrosoftGraphClient(config)
+        client = MicrosoftGraphClient(parsed_args.config_path, config)
         client.login()
 
         if parsed_args.discover:

--- a/tap_ms_teams/__init__.py
+++ b/tap_ms_teams/__init__.py
@@ -106,6 +106,7 @@ def main():
     ])
     config = parsed_args.config
 
+    client = None
     try:
         client = MicrosoftGraphClient(parsed_args.config_path, config)
         client.login()

--- a/tap_ms_teams/client.py
+++ b/tap_ms_teams/client.py
@@ -72,10 +72,19 @@ class MicrosoftGraphClient:
             }
 
             with singer.http_request_timer('POST get access token'):
-                result = self.make_request(
-                    method='POST',
-                    url=TOKEN_URL.format(tenant_id=self.tenant_id),
-                    data=body)
+                try:
+                    result = self.make_request(
+                        method='POST',
+                        url=TOKEN_URL.format(tenant_id=self.tenant_id),
+                        data=body)
+                except RuntimeError as e:
+                    # invalid_grant is returned as 400 — token is permanently dead; don't retry
+                    if 'invalid_grant' in str(e):
+                        raise Exception(
+                            'MS Teams refresh_token is expired or revoked. '
+                            'Re-authenticate via Stitch to obtain a new token. '
+                            'Details: {}'.format(str(e)))
+                    raise
 
             self.access_token = result.get('access_token')
             # Microsoft may rotate the refresh_token; keep the latest one in memory
@@ -84,9 +93,12 @@ class MicrosoftGraphClient:
                 self.refresh_token = new_refresh_token
                 self._write_config(new_refresh_token)
 
-        finally:
-            self.login_timer = threading.Timer(TOKEN_EXPIRATION_PERIOD,
-                                               self.login)
+        except Exception:
+            raise
+        else:
+            self.login_timer = threading.Timer(TOKEN_EXPIRATION_PERIOD, self.login)
+            # daemon=True ensures the timer thread does not keep the process alive
+            self.login_timer.daemon = True
             self.login_timer.start()
 
 

--- a/tap_ms_teams/client.py
+++ b/tap_ms_teams/client.py
@@ -1,5 +1,6 @@
 import codecs
 import csv
+import json
 import threading
 import urllib
 from enum import Enum
@@ -13,7 +14,6 @@ import singer.metrics
 LOGGER = singer.get_logger()  # noqa
 
 TOKEN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-SCOPE = "https://graph.microsoft.com/.default"
 BASE_GRAPH_URL = 'https://graph.microsoft.com'
 TOKEN_EXPIRATION_PERIOD = 3599
 TOP_API_PARAM_DEFAULT = 500
@@ -35,7 +35,8 @@ class MicrosoftGraphClient:
 
     MAX_TRIES = 5
 
-    def __init__(self, config):
+    def __init__(self, config_path, config):
+        self.config_path = config_path
         self.config = config
         self.session = requests.Session()
         self.login_timer = None
@@ -43,6 +44,7 @@ class MicrosoftGraphClient:
         self.client_secret = None
         self.client_id = None
         self.tenant_id = None
+        self.refresh_token = None
 
     @staticmethod
     def build_url(baseurl, version, path, args_dict):
@@ -57,13 +59,16 @@ class MicrosoftGraphClient:
         self.client_id = self.config.get('client_id')
         self.client_secret = self.config.get('client_secret')
         self.tenant_id = self.config.get('tenant_id')
+        # Use the in-memory refresh_token if already rotated, else fall back to config
+        if self.refresh_token is None:
+            self.refresh_token = self.config.get('refresh_token')
 
         try:
             body = {
-                'grant_type': 'client_credentials',
+                'grant_type': 'refresh_token',
                 'client_id': self.client_id,
                 'client_secret': self.client_secret,
-                'scope': SCOPE
+                'refresh_token': self.refresh_token,
             }
 
             with singer.http_request_timer('POST get access token'):
@@ -73,12 +78,25 @@ class MicrosoftGraphClient:
                     data=body)
 
             self.access_token = result.get('access_token')
+            # Microsoft may rotate the refresh_token; keep the latest one in memory
+            new_refresh_token = result.get('refresh_token')
+            if new_refresh_token and new_refresh_token != self.refresh_token:
+                self.refresh_token = new_refresh_token
+                self._write_config(new_refresh_token)
 
         finally:
             self.login_timer = threading.Timer(TOKEN_EXPIRATION_PERIOD,
                                                self.login)
             self.login_timer.start()
 
+
+    def _write_config(self, refresh_token):
+        LOGGER.info("Credentials Refreshed")
+        with open(self.config_path, encoding='utf-8') as f:
+            config = json.load(f)
+        config['refresh_token'] = refresh_token
+        with open(self.config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=2)
 
     def get_all_resources(self,
                           version,

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,3 +1,6 @@
+import json
+import os
+import tempfile
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 from tap_ms_teams.client import MicrosoftGraphClient, Server5xxError, Server42xRateLimitError
@@ -7,6 +10,7 @@ default_config = {
     "client_id": "test_client_id",
     "client_secret": "test_client_secret",
     "tenant_id": "test_tenant_id",
+    "refresh_token": "test_refresh_token",
     "user_agent": "test_user_agent"
 }
 
@@ -30,7 +34,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_client_initialization(self, mock_session):
         """Test that client initializes correctly with config"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
 
         self.assertEqual(client.config, default_config)
         self.assertIsNone(client.access_token)
@@ -41,7 +45,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_login_success(self, mock_session, mock_timer):
         """Test successful login and token refresh"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
 
         mock_response = MockResponse(
             200,
@@ -74,7 +78,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_get_all_resources_with_pagination(self, mock_session):
         """Test fetching all resources with pagination"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
 
         # Mock paginated responses
@@ -100,7 +104,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_make_request_rate_limit_retry(self, mock_session, mock_sleep):
         """Test that rate limit triggers retry with proper wait"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
 
         # Mock rate limit response that will be returned every time
@@ -122,7 +126,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_make_request_401_triggers_relogin(self, mock_session):
         """Test that 401 status triggers login attempt"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'expired_token'
         client.login = MagicMock()
 
@@ -141,7 +145,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_make_request_500_raises_server_error(self, mock_session):
         """Test that 500 status raises Server5xxError"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
 
         server_error_response = MockResponse(500)
@@ -155,7 +159,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_make_request_post_method(self, mock_session):
         """Test POST request with data"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
 
         success_response = MockResponse(200, json_data={'access_token': 'new_token'})
@@ -174,7 +178,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
 
     def test_make_request_unsupported_method(self):
         """Test that unsupported HTTP method raises exception"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
 
         with self.assertRaises(Exception) as context:
@@ -185,7 +189,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.get')
     def test_stream_csv(self, mock_get):
         """Test CSV streaming functionality"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
 
         mock_response = Mock()
         mock_response.iter_lines.return_value = [
@@ -207,7 +211,7 @@ class TestMicrosoftGraphClient(unittest.TestCase):
     @patch('tap_ms_teams.client.requests.Session')
     def test_get_report_with_rate_limit(self, mock_session, mock_sleep):
         """Test get_report handles rate limiting"""
-        client = MicrosoftGraphClient(default_config)
+        client = MicrosoftGraphClient(None, default_config)
         client.access_token = 'test_token'
         client.stream_csv = MagicMock(return_value=[])
 
@@ -220,3 +224,100 @@ class TestMicrosoftGraphClient(unittest.TestCase):
             list(client.get_report('v1.0', 'reports/getTeamsDeviceUsageUserDetail'))
 
         mock_sleep.assert_called_with(30)
+
+
+class TestRefreshTokenRotation(unittest.TestCase):
+
+    def _make_config_file(self, config):
+        tmp = tempfile.NamedTemporaryFile('w', suffix='.json', delete=False, encoding='utf-8')
+        json.dump(config, tmp)
+        tmp.close()
+        return tmp.name
+
+    @patch('tap_ms_teams.client.threading.Timer')
+    @patch('tap_ms_teams.client.requests.Session')
+    def test_rotated_refresh_token_is_persisted(self, mock_session, mock_timer):
+        """When Microsoft returns a new refresh_token it is written to config file"""
+        config = dict(default_config)
+        config_path = self._make_config_file(config)
+        try:
+            client = MicrosoftGraphClient(config_path, config)
+            mock_session_instance = mock_session.return_value
+            mock_session_instance.post.return_value = MockResponse(200, json_data={
+                'access_token': 'new_access',
+                'refresh_token': 'rotated_refresh_token'
+            })
+
+            client.login()
+
+            self.assertEqual(client.refresh_token, 'rotated_refresh_token')
+            with open(config_path, encoding='utf-8') as f:
+                saved = json.load(f)
+            self.assertEqual(saved['refresh_token'], 'rotated_refresh_token')
+        finally:
+            os.unlink(config_path)
+
+    @patch('tap_ms_teams.client.threading.Timer')
+    @patch('tap_ms_teams.client.requests.Session')
+    def test_unchanged_refresh_token_not_written(self, mock_session, mock_timer):
+        """When Microsoft returns the same refresh_token, _write_config is not called"""
+        config = dict(default_config)
+        config_path = self._make_config_file(config)
+        try:
+            client = MicrosoftGraphClient(config_path, config)
+            client._write_config = MagicMock()
+            mock_session_instance = mock_session.return_value
+            mock_session_instance.post.return_value = MockResponse(200, json_data={
+                'access_token': 'new_access',
+                'refresh_token': 'test_refresh_token'  # same as default_config
+            })
+
+            client.login()
+
+            client._write_config.assert_not_called()
+        finally:
+            os.unlink(config_path)
+
+    @patch('tap_ms_teams.client.threading.Timer')
+    @patch('tap_ms_teams.client.requests.Session')
+    def test_missing_refresh_token_in_response_not_written(self, mock_session, mock_timer):
+        """When Microsoft omits refresh_token in response, existing token is preserved"""
+        config = dict(default_config)
+        config_path = self._make_config_file(config)
+        try:
+            client = MicrosoftGraphClient(config_path, config)
+            client._write_config = MagicMock()
+            mock_session_instance = mock_session.return_value
+            mock_session_instance.post.return_value = MockResponse(200, json_data={
+                'access_token': 'new_access'
+                # no refresh_token key
+            })
+
+            client.login()
+
+            client._write_config.assert_not_called()
+            self.assertEqual(client.refresh_token, 'test_refresh_token')
+        finally:
+            os.unlink(config_path)
+
+    @patch('tap_ms_teams.client.threading.Timer')
+    @patch('tap_ms_teams.client.requests.Session')
+    def test_invalid_grant_raises_and_no_timer(self, mock_session, mock_timer):
+        """invalid_grant raises immediately and does not restart the timer"""
+        client = MicrosoftGraphClient(None, default_config)
+        mock_session_instance = mock_session.return_value
+        mock_session_instance.post.return_value = MockResponse(
+            400,
+            text='{"error": "invalid_grant", "error_description": "Token has expired"}'
+        )
+
+        with self.assertRaises(Exception) as ctx:
+            client.login()
+
+        self.assertIn('expired or revoked', str(ctx.exception))
+        mock_timer.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
Updates tap-ms-teams to use the OAuth `refresh_token` grant instead of
`client_credentials`, aligning the tap with the Stitch platform OAuth flow
implemented in the connections-service.

## Changes

### `tap_ms_teams/client.py`
- `__init__`: accepts `config_path` parameter for writing rotated tokens back
  to disk; adds `self.refresh_token = None`
- `login()`: switches grant type from `client_credentials` to `refresh_token`;
  reads initial `refresh_token` from config on first call, reuses in-memory
  value on subsequent timer-triggered calls
- `_write_config(refresh_token)`: writes the rotated `refresh_token` back to
  the config file when Microsoft issues a new one (same pattern as tap-quickbooks)
- Removed unused `SCOPE` constant (`refresh_token` grant does not take a scope)

### `tap_ms_teams/__init__.py`
- `refresh_token` added to `required_config_keys` — tap fails fast with a
  clear error if the credential is missing
- Passes `parsed_args.config_path` to `MicrosoftGraphClient`

## Config keys required (after this change)

| Key | Description |
|---|---|
| `client_id` | Stitch Azure AD app client ID |
| `client_secret` | Stitch Azure AD app client secret |
| `tenant_id` | Customer's Azure AD tenant ID |
| `refresh_token` | OAuth refresh token from Stitch authorization flow |
| `start_date` | Replication start date |
| `user_agent` | User agent string |


## Testing
- Run tap with a valid config containing `refresh_token` — token exchange
  succeeds and `access_token` is obtained
- Simulate token rotation by returning a new `refresh_token` from the mock
  — verify config file is updated on disk